### PR TITLE
Make thumb shadow optional

### DIFF
--- a/Sources/MultiSlider.swift
+++ b/Sources/MultiSlider.swift
@@ -88,6 +88,11 @@ open class MultiSlider: UIControl
             invalidateIntrinsicContentSize()
         }
     }
+    @IBInspectable @objc public var showsThumbImageShadow: Bool = true {
+        didSet {
+            updateThumbViewShadowVisibility()
+        }
+    }
     @IBInspectable @objc open var minimumImage: UIImage? {
         get {
             return minimumView.image
@@ -275,6 +280,13 @@ open class MultiSlider: UIControl
         positionThumbView(i)
         thumbView.blur(disabledThumbIndices.contains(i))
         addValueLabel(i)
+        updateThumbViewShadowVisibility()
+    }
+
+    private func updateThumbViewShadowVisibility() {
+        thumbViews.forEach {
+            $0.layer.shadowOpacity = showsThumbImageShadow ? 0.25 : 0
+        }
     }
 
     private func addValueLabel(_ i: Int) {


### PR DESCRIPTION
This adds a Bool `showsThumbImageShadow` property to MultiSlider (default `true`) to disable the shadow on the thumb images.

```swift
showsThumbImageShadow = false
```

![showsthumbimageshadow0](https://user-images.githubusercontent.com/944121/36849192-a533349c-1d63-11e8-87a8-36abe750a214.png)