### PR TITLE
Add option for round track ends

### DIFF
--- a/Sources/MultiSlider.swift
+++ b/Sources/MultiSlider.swift
@@ -119,8 +119,15 @@ open class MultiSlider: UIControl
             let widthAttribute: NSLayoutAttribute = orientation == .vertical ? .width : .height
             trackView.removeFirstConstraintWhere { $0.firstAttribute == widthAttribute }
             trackView.constrain(widthAttribute, to: trackWidth)
+            updateTrackViewCornerRounding()
         }
     }
+    @IBInspectable @objc public var hasRoundTrackEnds: Bool = false {
+        didSet {
+            updateTrackViewCornerRounding()
+        }
+    }
+
     open var valueLabelFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.maximumFractionDigits = 2
@@ -214,7 +221,7 @@ open class MultiSlider: UIControl
 
     private func setup() {
         trackView.backgroundColor = actualTintColor
-        trackView.layer.cornerRadius = 1
+        updateTrackViewCornerRounding()
         slideView.layoutMargins = .zero
         setupOrientation()
 
@@ -379,6 +386,10 @@ open class MultiSlider: UIControl
         else {
             constrain(trackView, at: edge, to: self, at: superviewEdge)
         }
+    }
+
+    private func updateTrackViewCornerRounding() {
+        trackView.layer.cornerRadius = hasRoundTrackEnds ? trackWidth / 2 : 1
     }
 
     // MARK: - Overrides

--- a/Sources/MultiSlider.swift
+++ b/Sources/MultiSlider.swift
@@ -122,7 +122,7 @@ open class MultiSlider: UIControl
             updateTrackViewCornerRounding()
         }
     }
-    @IBInspectable @objc public var hasRoundTrackEnds: Bool = false {
+    @IBInspectable @objc public var hasRoundTrackEnds: Bool = true {
         didSet {
             updateTrackViewCornerRounding()
         }


### PR DESCRIPTION
This adds a Bool property `hasRoundTrackEnds` (default `false`) to make the track ends round. This option makes more sense for wider tracks.

```swift
hasRoundTrackEnds = true
trackWidth = 10
```

![trackwidth10hasroundtrackends1](https://user-images.githubusercontent.com/944121/36849387-3bacbbfa-1d64-11e8-8310-93d555ef75fd.png)

```swift
hasRoundTrackEnds = true
trackWidth = 40
```

![trackwidth40hasroundtrackends1](https://user-images.githubusercontent.com/944121/36849444-5f93720c-1d64-11e8-8298-c8a6126765f1.png)