### PR TITLE
Fix package.swift iOS version for swiftui

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "MultiSlider",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v13),
     ],
     products: [
         .library(name: "MultiSlider", targets: ["MultiSlider"]),


### PR DESCRIPTION
update to `Package.swift` for the swiftui branch which is required to build for archiving.