### PR TITLE
add value label text property

### DIFF
--- a/Sources/MultiSlider+Internal.swift
+++ b/Sources/MultiSlider+Internal.swift
@@ -189,13 +189,17 @@ extension MultiSlider {
     }
 
     func updateValueLabel(_ i: Int) {
-        let labelValue: CGFloat
-        if isValueLabelRelative {
-            labelValue = i > 0 ? value[i] - value[i - 1] : value[i] - minimumValue
+        if valueLabelTexts.count == thumbCount {
+            valueLabels[i].text = valueLabelTexts[i]
         } else {
-            labelValue = value[i]
+            let labelValue: CGFloat
+            if isValueLabelRelative {
+                labelValue = i > 0 ? value[i] - value[i - 1] : value[i] - minimumValue
+            } else {
+                labelValue = value[i]
+            }
+            valueLabels[i].text = valueLabelFormatter.string(from: NSNumber(value: Double(labelValue)))
         }
-        valueLabels[i].text = valueLabelFormatter.string(from: NSNumber(value: Double(labelValue)))
     }
 
     func updateAllValueLabels() {

--- a/Sources/MultiSlider.swift
+++ b/Sources/MultiSlider.swift
@@ -97,6 +97,14 @@ open class MultiSlider: UIControl {
         }
     }
 
+    @IBInspectable open dynamic var valueLabelTexts: [String] = [] {
+        didSet {
+            if valueLabelTexts.count == thumbCount {
+                valueLabels.enumerated().forEach { $1.text = valueLabelTexts[$0] } // needs to handle array with different length
+            }
+        }
+    }
+
     @IBInspectable open dynamic var valueLabelColor: UIColor? {
         didSet {
             valueLabels.forEach { $0.textColor = valueLabelColor }


### PR DESCRIPTION
There is a demand to use custom text for `valueLabel`, such as below.
<img width="634" alt="slider-with-label-text" src="https://user-images.githubusercontent.com/43233145/152627759-852820ad-eb83-4be8-b82d-2f0611b273c3.png">

This revision enables to set custom text by passing string array.
```multiSlider.valueLabelTexts = ["value1", "value2"]```

Below are the points that can be considered
- In this implementation, when the size of `valueLabelTexts` differs from the size of `value`, original text (which is the value) is displayed.
- It might be better to rename `valueLabel` to a name such as `thumbLabel`, since the label will not always be a value.