### PR TITLE
Update MultiSlider.swift

### DIFF
--- a/Sources/MultiSlider.swift
+++ b/Sources/MultiSlider.swift
@@ -203,7 +203,7 @@ open class MultiSlider: UIControl {
     }
 
     /// Return value label text for a thumb index and value. If `nil`, then `valueLabelFormatter` will be used instead.
-    @objc open dynamic var valueLabelTextForThumb: ((Int, CGFloat) -> String)? {
+    @objc open dynamic var valueLabelTextForThumb: ((Int, CGFloat) -> String?)? {
         didSet {
             for i in valueLabels.indices {
                 updateValueLabel(i)


### PR DESCRIPTION
This change allows returning nil from `valueLabelTextForThumb`. This behavior is nearly identical to the current behavior that occurs when `valueLabelTextForThumb` is unimplemented, except that this allows the user to implement `valueLabelTextForThumb` and conditionally return or not return a value. 

In case a user returns nil from the `valueLabelTextForThumb` closure, the labels value will default to the result of `valueLabelFormatter`.

An example of a conditional use case is shown below:

```
public var maximum: Double = 500.0
...
        slider.thumbCount = 2
        slider.minimumValue = 0
        slider.maximumValue = maximum
        slider.value = [0, maximum]
        slider.valueLabelFormatter = CurrencyFormatter.formatter
        slider.valueLabelTextForThumb = { idx, value in
            guard
                idx == 1 && value == self.maximum,
                let price = CurrencyFormatter.formatter.string(from: NSNumber(floatLiteral: value)) else {
                return nil
            }
            return "MAX PRICE"
        }
```